### PR TITLE
Yaml support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ export AWS_DEFAULT_REGION=
 ```
 
 ### Export
-This command exports the Parameters into a specified format. Currently, only exporting as JSON is supported.
+This command exports the Parameters into a specified format. Currently, only exporting as JSON and YAML is supported.
 ```shell script
 $ ./configurator export --paths /Path1,/Path2
 ```

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,5 +22,90 @@ func TestRemovePrefix(t *testing.T) {
 	for _, test := range tests {
 		actual := removePrefix(test.key, test.prefixLength)
 		require.Equal(t, test.expected, actual)
+	}
+}
+
+func TestOutput(t *testing.T) {
+	tests := []map[string]interface{}{
+		// simulates a flat config
+		{
+			"Key1": "Value1",
+			"Key2": "Value2",
+			"Key3": "Value3",
+		},
+		// simulates a hierarchal config
+		{"Key1": map[string]interface{}{
+			"Key2": map[string]interface{}{
+				"Key3": "Value3",
+				"Key4": "Value4",
+			},
+			"Key5": "Value5",
+		}},
+	}
+
+	// inside the raw strings (``) use only spaces no tabs otherwise tests will fail
+	expects := []struct {
+		json, yaml []byte
+	}{
+		{
+			json: []byte(`{
+  "Key1": "Value1",
+  "Key2": "Value2",
+  "Key3": "Value3"
+}
+`),
+			yaml: []byte(`Key1: Value1
+Key2: Value2
+Key3: Value3
+`),
+		},
+		{
+			json: []byte(`{
+  "Key1": {
+    "Key2": {
+      "Key3": "Value3",
+      "Key4": "Value4"
+    },
+    "Key5": "Value5"
+  }
+}
+`),
+			yaml: []byte(`Key1:
+  Key2:
+    Key3: Value3
+    Key4: Value4
+  Key5: Value5
+`),
+		},
+	}
+
+	indent = true
+
+	for i, v := range tests {
+		t.Run(fmt.Sprintf("JSON-%d", i+1), func(st *testing.T) {
+			buf := bytes.NewBuffer([]byte{})
+			err := exportAsJSON(v, buf)
+			if err != nil {
+				st.Fatalf("An error occurred while formating JSON(%v): %v", v, err)
+			}
+
+			b := buf.Bytes()
+			if bytes.Compare(expects[i].json, b) != 0 {
+				st.Fatalf("Expected: %q\nbut\ngot: %q", expects[i].json, b)
+			}
+		})
+
+		t.Run(fmt.Sprintf("YAML-%d", i+1), func(st *testing.T) {
+			buf := bytes.NewBuffer([]byte{})
+			err := exportAsYAML(v, buf)
+			if err != nil {
+				st.Fatalf("An error occurred while formating YAML(%v): %v", v, err)
+			}
+
+			b := buf.Bytes()
+			if bytes.Compare(expects[i].yaml, b) != 0 {
+				st.Fatalf("Expected: %q\nbut\ngot: %q", expects[i].yaml, b)
+			}
+		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.6
 	github.com/stretchr/testify v1.4.0
-	gopkg.in/yaml.v2 v2.2.2
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.6
 	github.com/stretchr/testify v1.4.0
+	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )
 
 go 1.14

--- a/go.sum
+++ b/go.sum
@@ -144,4 +144,6 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Hi,
In accordance with issue https://github.com/banknovo/configurator/issues/5, I have added support for YAML output of the config files

This pull request adds one dependency: [gopkg.in/yaml](https://pkg.go.dev/gopkg.in/yaml.v3)

Other than that there is a test case to check the output of both `exportAsJSON` and `exportAsYAML` functions

I hope this pull request be of some use : )